### PR TITLE
adding a template config file for qrz service. fixes #12

### DIFF
--- a/qrz.config.template
+++ b/qrz.config.template
@@ -1,0 +1,5 @@
+[credentials]
+# Replace 'your_username', 'your_password', and 'your_api_key' with your actual credentials for qrz.com
+username = CALLSIGN
+password = PASSWORD
+api_key = API_KEY_FROM_QRZ_XOM


### PR DESCRIPTION
I have added a template config file for qrz.com service.
one should still fill in username/passwod/api_key.
This fixes #12